### PR TITLE
[nginx] Upgrade nginx to v18.2.2

### DIFF
--- a/nginx/Chart.yaml
+++ b/nginx/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
-name: nginx
-description: Basic nginx chart
-version: 0.1.0
-appVersion: "1.16.0"
-
+appVersion: 1.16.0
 dependencies:
-- name: nginx
-  repository: https://charts.bitnami.com/bitnami
-  version: 18.2.0
+    - name: nginx
+      repository: https://charts.bitnami.com/bitnami
+      version: 18.2.2
+description: Basic nginx chart
+name: nginx
+version: 0.1.1


### PR DESCRIPTION
## Upgrade nginx to v18.2.2

### Release Notes


### More Info
[View the Helm chart release notes](https://artifacthub.io/packages/helm/bitnami/nginx)