### PR TITLE
[grafana] Upgrade grafana to v8.5.2

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
-name: grafana
-description: A Helm chart for Kubernetes
-version: 8.4.7
 appVersion: 11.2.1
-
 dependencies:
-- name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 8.4.7
+    - name: grafana
+      repository: https://grafana.github.io/helm-charts
+      version: 8.5.2
+description: A Helm chart for Kubernetes
+name: grafana
+version: 8.5.2


### PR DESCRIPTION
## Upgrade grafana to v8.5.2

### Release Notes
Major upgrade detected. Upgrading to the last minor version 8.5.2.
Version 8.5.2:
The leading tool for querying and visualizing time series and metrics.

Version 8.5.1:
The leading tool for querying and visualizing time series and metrics.

Version 8.5.0:
The leading tool for querying and visualizing time series and metrics.

Version 8.4.9:
The leading tool for querying and visualizing time series and metrics.

Version 8.4.8:
The leading tool for querying and visualizing time series and metrics.

Version 8.4.7:
The leading tool for querying and visualizing time series and metrics.



### More Info
[View the Helm chart release notes](https://artifacthub.io/packages/helm/grafana/grafana)