### PR TITLE
[grafana] Upgrade grafana to v7.3.9

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
-name: grafana
-description: A Helm chart for Kubernetes
-version: 8.4.7
 appVersion: 11.2.1
-
 dependencies:
-- name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 7.3.0
+    - name: grafana
+      repository: https://grafana.github.io/helm-charts
+      version: 7.3.9
+description: A Helm chart for Kubernetes
+name: grafana
+version: 8.4.8


### PR DESCRIPTION
## Upgrade grafana to v7.3.9

### Release Notes
Major upgrade detected. Upgrading to the last minor version 7.3.9.
Version 7.3.9:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.8:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.7:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.6:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.5:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.4:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.3:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.2:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.12:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.11:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.10:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.1:
The leading tool for querying and visualizing time series and metrics.

Version 7.3.0:
The leading tool for querying and visualizing time series and metrics.



### More Info
[View the Helm chart release notes](https://artifacthub.io/packages/helm/grafana/grafana)