### PR TITLE
[grafana] Upgrade grafana to v7.3.9

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
 name: grafana
 description: A Helm chart for Kubernetes
-version: 7.3.0
+version: 7.3.9
 appVersion: 11.2.1
-
 dependencies:
-- name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 7.3.0
+  - name: grafana
+    repository: https://grafana.github.io/helm-charts
+    version: 7.3.9


### PR DESCRIPTION
## Upgrade grafana to v7.3.9

### Release Notes
Major upgrade detected. Upgrading to the last minor version 7.3.9.
Version 7.3.9:
No release notes available

Version 7.3.8:
No release notes available

Version 7.3.7:
No release notes available

Version 7.3.6:
No release notes available

Version 7.3.5:
No release notes available

Version 7.3.4:
No release notes available

Version 7.3.3:
No release notes available

Version 7.3.2:
No release notes available

Version 7.3.12:
No release notes available

Version 7.3.11:
No release notes available

Version 7.3.10:
No release notes available

Version 7.3.1:
No release notes available

Version 7.3.0:
No release notes available



### More Info
[View the Helm chart release notes](https://artifacthub.io/packages/helm/grafana/grafana)