### PR TITLE
[grafana] Upgrade grafana to v7.3.9

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
 name: grafana
 description: A Helm chart for Kubernetes
-version: 7.3.0
+version: 7.3.9
 appVersion: 11.2.1
-
 dependencies:
-- name: grafana
-  repository: https://grafana.github.io/helm-charts
-  version: 7.3.0
+  - name: grafana
+    repository: https://grafana.github.io/helm-charts
+    version: 7.3.9


### PR DESCRIPTION
## Upgrade grafana to v7.3.9

### *NOTE: Major upgrade detected. Upgrading to the last minor version `7.3.9`.*



 Release Notes


### More Info
[View the Helm chart release notes](https://artifacthub.io/packages/helm/grafana/grafana)