### PR TITLE
[grafana] Upgrade grafana to v7.3.9

### DIFF
--- a/grafana/Chart.yaml
+++ b/grafana/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: grafana
 description: A Helm chart for Kubernetes
-version: 7.3.1
+version: 7.3.2
 appVersion: 11.2.1
 dependencies:
   - name: grafana


### PR DESCRIPTION
## Upgrade grafana to v7.3.9

### Release Notes
*NOTE:* Major upgrade detected. Upgrading to the last minor version `7.3.9`.

Version 7.3.9:
No release notes available



### More Info
[View the Helm chart release notes](https://artifacthub.io/packages/helm/grafana/grafana)